### PR TITLE
JET API catches and handles all internal exceptions

### DIFF
--- a/BuildESE.bat
+++ b/BuildESE.bat
@@ -3,6 +3,6 @@
 rem NOTE: Make sure the path does not have white spaces
 set "scriptDir=%~dp0"
 
-cmake --no-warn-unused-cli -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -H%scriptDir% -B%scriptDir%\build -G "Visual Studio 15 2017" -T host=x64 -A x64
+cmake --no-warn-unused-cli -DCMAKE_EXPORT_COMPILE_COMMANDS:BOOL=TRUE -H%scriptDir% -B%scriptDir%\build -G "Visual Studio 16 2019" -T host=x64 -A x64
 
 cmake --build %scriptDir%/build --config Release --target ALL_BUILD -- /maxcpucount:10


### PR DESCRIPTION
This update prevents system exceptions (access violation, floating point errors, etc.) from leaving the confines of the ESE library and crashing the calling process. 